### PR TITLE
Rework attack interface to be more accurate

### DIFF
--- a/objects/obj_attackpress/Draw_0.gml
+++ b/objects/obj_attackpress/Draw_0.gml
@@ -45,7 +45,7 @@ if (active == 1)
             j = global.char[i];
             fullbox = 0;
 			
-			var _col = scr_hero_get_color(j - 1);
+			var _col = scr_hero_get_attackpress_color(j - 1);
 			draw_set_color(_col);
 			
 			if (pressbuffer[clamp(j, 0, 3)])

--- a/objects/obj_attackpress/Draw_0.gml
+++ b/objects/obj_attackpress/Draw_0.gml
@@ -51,7 +51,7 @@ if (active == 1)
 			if (pressbuffer[clamp(j, 0, 3)])
 				draw_set_color(merge_color(_col, c_white, pressbuffer[clamp(j, 0, 3)] / 5));
             
-            draw_rectangle(x + 78, y + (38 * i), x + 80 + (15 * boltspeed), y + (38 * i) + 36, true);
+            draw_rectangle(x + 78, y + (38 * i) + 1, x + 80 + (15 * boltspeed), y + (38 * i) + 36, true);
             draw_rectangle(x + 79, y + (38 * i) + 2, (x + 80 + (15 * boltspeed)) - 1, y + (38 * i) + 35, true);
             //draw_sprite(spr_pressfront, j - 1, x, y + (38 * i));
 			
@@ -65,7 +65,19 @@ if (active == 1)
                 draw_sprite(spr_pressfront_b, i, x, y + (38 * i));
             
             //draw_sprite(spr_pressspot, j - 1, x + 80, y + (38 * i));
-			draw_sprite(spr_pressspot, 4, x + 80, y + (38 * i));
+			//draw_sprite(spr_pressspot, 4, x + 80, y + (38 * i));
+			var presspot_width = 10
+			var presspot_height = 38
+			
+			var _x2 = x + 80 + presspot_width
+			var _y2 = y + presspot_height + (38 * i)
+			var _pressspot_col = scr_hero_get_attacktarget_color(j - 1)
+			draw_set_color(_pressspot_col)
+			draw_rectangle(x + 80, y + (38 * i), _x2, _y2, false)
+			
+			draw_set_color(c_black)
+			draw_rectangle(x + 82, y + (38 * i) + 2, _x2 - 2, _y2 - 2, false)
+			draw_set_color(c_white)
         }
     }
     

--- a/objects/obj_attackpress/Draw_0.gml
+++ b/objects/obj_attackpress/Draw_0.gml
@@ -45,7 +45,7 @@ if (active == 1)
             j = global.char[i];
             fullbox = 0;
 			
-			var _col = scr_hero_get_attackpress_color(j - 1);
+			var _col = scr_hero_get_attackbackground_color(j - 1);
 			draw_set_color(_col);
 			
 			if (pressbuffer[clamp(j, 0, 3)])

--- a/objects/obj_burstbolt/Step_0.gml
+++ b/objects/obj_burstbolt/Step_0.gml
@@ -2,7 +2,7 @@ image_alpha -= 0.1;
 image_xscale += mag;
 image_yscale += mag;
 x += ((1 - sprite_width) * mag) / 2.7;
-x += ((1 - sprite_height) * mag) / 2.5;
+y += ((1 - sprite_height) * mag) / 2.5;
 
 if image_alpha < 0
 	instance_destroy();

--- a/scripts/scr_heroes_config/scr_heroes_config.gml
+++ b/scripts/scr_heroes_config/scr_heroes_config.gml
@@ -72,6 +72,19 @@ function scr_hero_get_attackpress_color(heroIdx) {
 	}
 }
 
+function scr_hero_get_attacktarget_color(heroIdx) {
+	switch (heroIdx) {
+		case DRHero.Kris:	return make_color_rgb(0, 162, 232);
+		case DRHero.Susie:	return make_color_rgb(234, 121, 200);
+		case DRHero.Ralsei: return make_color_rgb(181, 230, 29);
+		case DRHero.Noelle: return make_color_rgb(255, 255, 153);
+		
+		case DRHero.Starwalker: return make_color_rgb(255, 255, 153);
+		
+		default: return c_white;
+	}
+}
+
 function scr_hero_get_battle_instance(heroIdx) {
 	switch (heroIdx) {
 		case DRHero.Kris:	return obj_herokris;

--- a/scripts/scr_heroes_config/scr_heroes_config.gml
+++ b/scripts/scr_heroes_config/scr_heroes_config.gml
@@ -78,7 +78,7 @@ function scr_hero_get_attacktarget_color(heroIdx) {
 		
 		case DRHero.Starwalker: return make_color_rgb(255, 255, 153);
 		
-		default: return scr_hero_get_color(heroIdx);
+		default: return c_white;
 	}
 }
 

--- a/scripts/scr_heroes_config/scr_heroes_config.gml
+++ b/scripts/scr_heroes_config/scr_heroes_config.gml
@@ -59,6 +59,19 @@ function scr_hero_get_color(heroIdx) {
 	}
 }
 
+function scr_hero_get_attackpress_color(heroIdx) {
+	switch (heroIdx) {
+		case DRHero.Kris:	return c_blue;
+		case DRHero.Susie:	return c_purple;
+		case DRHero.Ralsei: return c_green;
+		case DRHero.Noelle: return c_yellow;
+		
+		case DRHero.Starwalker: return c_yellow;
+		
+		default: return c_white;
+	}
+}
+
 function scr_hero_get_battle_instance(heroIdx) {
 	switch (heroIdx) {
 		case DRHero.Kris:	return obj_herokris;

--- a/scripts/scr_heroes_config/scr_heroes_config.gml
+++ b/scripts/scr_heroes_config/scr_heroes_config.gml
@@ -59,16 +59,13 @@ function scr_hero_get_color(heroIdx) {
 	}
 }
 
-function scr_hero_get_attackpress_color(heroIdx) {
+function scr_hero_get_attackbackground_color(heroIdx) {
 	switch (heroIdx) {
 		case DRHero.Kris:	return c_blue;
 		case DRHero.Susie:	return c_purple;
 		case DRHero.Ralsei: return c_green;
-		case DRHero.Noelle: return c_yellow;
 		
-		case DRHero.Starwalker: return c_yellow;
-		
-		default: return c_white;
+		default: return scr_hero_get_color(heroIdx);
 	}
 }
 
@@ -81,7 +78,7 @@ function scr_hero_get_attacktarget_color(heroIdx) {
 		
 		case DRHero.Starwalker: return make_color_rgb(255, 255, 153);
 		
-		default: return c_white;
+		default: return scr_hero_get_color(heroIdx);
 	}
 }
 


### PR DESCRIPTION
upon messing with this a bit, i noticed that the rendering for the attack minigame in battles was severely different from the actual game. 
this PR fixes that, by fixing a typo in obj_burstbolt_step_0.gml, and introducing scr_heroes_get_attackpress_color and scr_heroes_get_attacktarget_color. spr_presssprite is no longer used for rendering the target window, instead ive reworked that to be drawn with code, allowing for easy hero color changes

Before screenshot:
<img width="1276" height="341" alt="image" src="https://github.com/user-attachments/assets/a086b13b-9e8d-4b8e-ba95-a3c077ef6224" />


After screenshot:
<img width="1265" height="308" alt="image" src="https://github.com/user-attachments/assets/9a520160-fd9f-43c0-898f-202fb5feeda8" />
